### PR TITLE
feat: add command line argument to fine tune cassandra concurrency

### DIFF
--- a/scripts/blocksci_export.py
+++ b/scripts/blocksci_export.py
@@ -63,8 +63,6 @@ def query_most_recent_block(cluster, keyspace):
 
 class QueryManager(ABC):
 
-    # chosen to match the default in execute_concurrent_with_args
-    concurrency = 100
     counter = Value('d', 0)
 
     def __init__(self, cluster, keyspace, chain, cql_str,
@@ -73,6 +71,7 @@ class QueryManager(ABC):
             num_chunks = num_proc
         self.num_proc = num_proc
         self.num_chunks = num_chunks
+        self.concurrency = concurrency
         self.pool = Pool(processes=num_proc,
                          initializer=self._setup,
                          initargs=(cluster, chain, keyspace, cql_str))


### PR DESCRIPTION
Allow for fine tuning of the Cassandra client concurrency parameter with a command line argument to the `blocksci_export.py` script. 
The Cassandra [clients docs](https://docs.datastax.com/en/developer/python-driver/3.24/api/cassandra/concurrent/) gives more details about how it can be used to leverage multiple Cassandra nodes and about its usage. 
Feel free to `cherry pick` the changes and to make it you own (or not :wink: ).  